### PR TITLE
Add placeholder UI for index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,16 +8,56 @@
   <link rel="manifest" href="manifest.webmanifest">
 </head>
 <body class="bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
-  <div id="app"></div>
+  <div id="app" class="p-4 space-y-4">
+    <header class="flex justify-between items-center">
+      <h1 class="text-xl font-bold">Maladum Crafting</h1>
+      <button class="text-sm px-2 py-1 border rounded">⚙️</button>
+    </header>
+    <main class="space-y-6">
+      <section>
+        <h2 class="font-semibold mb-2">Materials</h2>
+        <div class="grid grid-cols-4 gap-2">
+          <div class="border rounded p-2 flex flex-col items-center text-center">
+            <div class="font-bold">W</div>
+            <div class="text-sm">1</div>
+            <div class="mt-1 flex space-x-1">
+              <button class="px-2 border rounded">–</button>
+              <button class="px-2 border rounded">+</button>
+            </div>
+          </div>
+          <div class="border rounded p-2 flex flex-col items-center text-center">
+            <div class="font-bold">S</div>
+            <div class="text-sm">0</div>
+            <div class="mt-1 flex space-x-1">
+              <button class="px-2 border rounded">–</button>
+              <button class="px-2 border rounded">+</button>
+            </div>
+          </div>
+          <div class="border rounded p-2 flex flex-col items-center text-center">
+            <div class="font-bold">T</div>
+            <div class="text-sm">2</div>
+            <div class="mt-1 flex space-x-1">
+              <button class="px-2 border rounded">–</button>
+              <button class="px-2 border rounded">+</button>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section>
+        <h2 class="font-semibold mb-2">Craftable</h2>
+        <div class="space-y-1">
+          <div class="flex justify-between items-center border-b py-1">
+            <span>Arrow - Viscous/Sharp</span>
+            <button class="text-xl">☆</button>
+          </div>
+          <div class="flex justify-between items-center border-b py-1">
+            <span>Shillelagh</span>
+            <button class="text-xl">☆</button>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
   <script type="module" src="js/app.js"></script>
-  <script>
-    // Simple loading spinner for draft
-    document.getElementById('app').innerHTML = `
-      <div class='flex flex-col items-center justify-center min-h-screen'>
-        <div class='animate-spin rounded-full h-16 w-16 border-b-2 border-gray-900 mb-4'></div>
-        <p class='text-lg'>Loading Maladum Crafting Companion...</p>
-      </div>
-    `;
-  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fill out `index.html` with a simple placeholder layout
  - shows example material counters and craftable items

## Testing
- `npx --yes playwright test || true` *(fails: no tests)*

------
https://chatgpt.com/codex/tasks/task_e_6867087e380c8327b1adb91ef7c70461