### PR TITLE
feat: Display item icons and implement click-to-zoom functionality

### DIFF
--- a/js/ui/components.js
+++ b/js/ui/components.js
@@ -95,9 +95,11 @@ export function renderCraftableList(items, inventory, favourites) {
   list.innerHTML = craftable
     .map(item => {
       const starred = favourites.includes(item.name) ? '⭐' : '☆';
+      const iconPath = `images/tokens/${item.resources.icon}`;
       return `
         <div class="flex justify-between items-center border-b py-1">
-          <span>${item.name}</span>
+          <img src="${iconPath}" alt="${item.name} icon" class="item-icon w-8 h-8 mr-2 cursor-pointer">
+          <span class="flex-grow">${item.name}</span>
           <button data-fav="${item.name}" class="text-xl">${starred}</button>
         </div>`;
     })
@@ -109,6 +111,29 @@ export function renderCraftableList(items, inventory, favourites) {
       const favs = toggleFavourite(name);
       const inv = loadInventory();
       renderCraftableList(cachedItems, inv, favs);
+    });
+  });
+
+  list.querySelectorAll('.item-icon').forEach(icon => {
+    icon.addEventListener('click', () => {
+      const modal = document.createElement('div');
+      modal.classList.add('icon-modal');
+      modal.innerHTML = `
+        <div class="icon-modal-content">
+          <span class="icon-modal-close">&times;</span>
+          <img src="${icon.src}" alt="${icon.alt}" class="zoomed-icon">
+        </div>
+      `;
+      document.body.appendChild(modal);
+
+      modal.querySelector('.icon-modal-close').addEventListener('click', () => {
+        document.body.removeChild(modal);
+      });
+      modal.addEventListener('click', (e) => {
+        if (e.target === modal) { // Only close if clicking on the background
+          document.body.removeChild(modal);
+        }
+      });
     });
   });
 }

--- a/styles.css
+++ b/styles.css
@@ -56,3 +56,58 @@ body {
 .dark .material-card {
   background: rgba(17, 24, 39, 0.8);
 }
+
+/* Styles for item icons in the list */
+.item-icon {
+  /* Tailwind classes w-8 h-8 mr-2 are already applied for basic sizing */
+  /* Add any additional specific styles if needed, e.g., border */
+  border: 1px solid #ccc; /* Example border */
+  border-radius: 4px;
+  object-fit: contain; /* Ensure icon aspect ratio is maintained */
+}
+
+/* Styles for the icon zoom modal */
+.icon-modal {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000; /* Ensure it's on top */
+}
+
+.icon-modal-content {
+  position: relative;
+  background-color: var(--bg-light);
+  padding: 20px;
+  border-radius: 8px;
+  text-align: center;
+}
+
+.dark .icon-modal-content {
+  background-color: var(--bg-dark);
+}
+
+.icon-modal-close {
+  position: absolute;
+  top: 10px;
+  right: 15px;
+  font-size: 24px;
+  font-weight: bold;
+  cursor: pointer;
+  color: var(--text-light);
+}
+
+.dark .icon-modal-close {
+  color: var(--text-dark);
+}
+
+.zoomed-icon {
+  max-width: 80vw;
+  max-height: 80vh;
+  border-radius: 4px;
+}


### PR DESCRIPTION
- Updated `js/ui/components.js` to render item icons next to their names in the craftable items list.
- Implemented a modal to display a larger version of the icon when clicked.
- Added corresponding CSS styles in `styles.css` for the icons and the zoom modal, including dark mode support.