### PR TITLE
Fix: Correctly filter item resource icons in craftability check

### DIFF
--- a/js/crafting.js
+++ b/js/crafting.js
@@ -1,6 +1,7 @@
 // Craftability algorithm
 export function getCraftableItems(inventory, items) {
-  return items.filter(item =>
-    Object.entries(item.resources).every(([sym, qty]) =>
-      (inventory[sym] ?? 0) >= qty));
+  return items.filter(item => {
+    const requiredResources = Object.entries(item.resources).filter(([key]) => key !== 'icon');
+    return requiredResources.every(([sym, qty]) => (inventory[sym] ?? 0) >= qty);
+  });
 }


### PR DESCRIPTION
The getCraftableItems function was previously considering the 'icon' property within an item's resources as a required material. This caused items to be incorrectly evaluated as uncraftable because the string value of the icon filename was compared against material counts.

This commit updates getCraftableItems to filter out the 'icon' key from the resources before checking if all material quantities are met, ensuring accurate craftability assessment.