### PR TITLE
Fix favourites persistence

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2,11 +2,13 @@
 import { loadMaterials } from './materials.js';
 import { loadItems } from './items.js';
 import { renderHome } from './ui/components.js';
+import { initializeFavourites } from './favourites.js';
 import { setupTheme } from './ui/theme.js';
 import { applyRippleEffect } from './ui/effects.js'; // Import ripple effect
 import './pwa.js';
 
 window.addEventListener('DOMContentLoaded', async () => {
+  initializeFavourites();
   setupTheme();
   applyRippleEffect(); // Initialize ripple effect listeners globally
 

--- a/js/favourites.js
+++ b/js/favourites.js
@@ -1,14 +1,25 @@
 // Favourites management
 import { loadState, saveState } from './localStorageUtil.js';
 
+let currentFavourites = null;
+
+export function initializeFavourites() {
+  currentFavourites = loadState(FAVOURITES_KEY, DEFAULT_FAVOURITES);
+  return currentFavourites;
+}
+
 const FAVOURITES_KEY = 'maladum_favourites';
 const DEFAULT_FAVOURITES = [];
 
 export function loadFavourites() {
-  return loadState(FAVOURITES_KEY, DEFAULT_FAVOURITES);
+  if (currentFavourites === null) {
+    initializeFavourites();
+  }
+  return currentFavourites;
 }
 
 export function saveFavourites(favourites) {
+  currentFavourites = favourites;
   saveState(FAVOURITES_KEY, favourites);
 }
 


### PR DESCRIPTION
## Summary
- initialise favourites on startup
- keep favourites in memory and save to localStorage

## Testing
- `node --check js/favourites.js`

------
https://chatgpt.com/codex/tasks/task_e_6867be8b4e5c832799bb6f050369d2ce