### PR TITLE
Add crafting icon overlay to component cards

### DIFF
--- a/js/ui/components.js
+++ b/js/ui/components.js
@@ -140,7 +140,10 @@ export function renderMaterialsGrid(materials, inventory) {
       return `
         <div class="card flex flex-col items-center text-center p-2 ${rarityBorderCls}" data-material="${m.symbol}">
           <span class="rarity-badge ${rarityCls}"></span>
-          <div class="font-bold text-lg">${m.symbol}</div>
+          <div class="relative w-24 h-24 mb-2">
+            <img src="images/icons/crafting.png" alt="${m.name} icon" class="w-full h-full" />
+            <span class="absolute inset-0 flex items-center justify-center text-xs font-bold pointer-events-none">${m.name}</span>
+          </div>
           <div class="text-sm my-1">Cost: ${m.base_cost}</div>
           <div class="text-base my-1 count">${count}</div>
           <div class="mt-auto flex space-x-1">


### PR DESCRIPTION
## Summary
- show a standard crafting icon on material cards
- overlay the component name in the centre of the icon

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868061c81f88327b5919d8a4c2b84a1