### PR TITLE
Use item.price and rename label to Price

### DIFF
--- a/js/ui/components.js
+++ b/js/ui/components.js
@@ -232,7 +232,7 @@ export function renderAllItemsView(items, inventory, favourites) {
             <div class="text-sm space-y-1">
               <p><strong class="font-semibold">Requires:</strong> ${required || 'None'}</p>
               <p><strong class="font-semibold">Missing:</strong> <span class="${missingText === 'None' ? '' : 'text-red-500'}">${missingText}</span></p>
-              <p><strong class="font-semibold">Cost:</strong> ${item.total_cost}</p>
+              <p><strong class="font-semibold">Price:</strong> ${item.price}</p>
               <p><strong class="font-semibold">Expansion:</strong> ${item.expansion}</p>
             </div>
           </div>
@@ -354,7 +354,7 @@ export function renderCraftableItemsView(items, inventory, favourites) {
             <div class="text-sm space-y-1">
               <p><strong class="font-semibold">Requires:</strong> ${required || 'None'}</p>
               ${!isCraftable && favourites.includes(item.name) ? `<p><strong class="font-semibold">Missing:</strong> <span class="text-red-500">${missingText}</span></p>` : ''}
-              <p><strong class="font-semibold">Cost:</strong> ${item.total_cost}</p>
+              <p><strong class="font-semibold">Price:</strong> ${item.price}</p>
               <p><strong class="font-semibold">Expansion:</strong> ${item.expansion}</p>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- adjust item UI to read `item.price` instead of `item.total_cost`
- rename label from `Cost:` to `Price:` to be consistent

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6868142401e483278ba1a0423cd8c2ae