### PR TITLE
Add build cost calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A simple, mobile-first tool for tracking crafting materials and items in the Mal
 - JSON data uses a network-first strategy so updates are fetched when online.
 - Dark‑mode toggle available from the **Settings** screen.
 - Instant filtering of craftable items as you adjust inventory counts.
+- Displays a build cost for each item based on the price of any missing materials.
 
 For layout ideas, see the [Maladum Event Cards repo](https://github.com/BarryRodick/MaladumEventCards).
 

--- a/js/ui/components.js
+++ b/js/ui/components.js
@@ -44,6 +44,21 @@ function rarityBorderClass(rarity) {
   }
 }
 
+function calculateBuildCost(item, inventory) {
+  let total = 0;
+  Object.entries(item.resources).forEach(([sym, qty]) => {
+    if (sym === 'icon') return;
+    const have = inventory[sym] || 0;
+    if (have < qty) {
+      const mat = cachedMaterials.find(m => m.symbol === sym);
+      if (mat) {
+        total += (qty - have) * mat.base_cost;
+      }
+    }
+  });
+  return total;
+}
+
 export function renderHome(materials, items) {
   cachedMaterials = materials;
   cachedItems = items;
@@ -217,6 +232,8 @@ export function renderAllItemsView(items, inventory, favourites) {
         }
       }
 
+      const buildCost = calculateBuildCost(item, inventory);
+
       const rarity = calculateItemRarity(item);
       const rarityCls = rarityClass(rarity);
       const rarityBorderCls = rarityBorderClass(rarity);
@@ -234,6 +251,7 @@ export function renderAllItemsView(items, inventory, favourites) {
             <div class="text-sm space-y-1">
               <p><strong class="font-semibold">Requires:</strong> ${required || 'None'}</p>
               <p><strong class="font-semibold">Missing:</strong> <span class="${missingText === 'None' ? '' : 'text-red-500'}">${missingText}</span></p>
+              <p><strong class="font-semibold">Build Cost:</strong> ${buildCost}</p>
               <p><strong class="font-semibold">Price:</strong> ${item.price}</p>
               <p><strong class="font-semibold">Expansion:</strong> ${item.expansion}</p>
             </div>
@@ -336,6 +354,8 @@ export function renderCraftableItemsView(items, inventory, favourites) {
         }
       }
 
+      const buildCost = calculateBuildCost(item, inventory);
+
       const rarity = calculateItemRarity(item);
       const rarityCls = rarityClass(rarity);
       const rarityBorderCls = rarityBorderClass(rarity);
@@ -356,6 +376,7 @@ export function renderCraftableItemsView(items, inventory, favourites) {
             <div class="text-sm space-y-1">
               <p><strong class="font-semibold">Requires:</strong> ${required || 'None'}</p>
               ${!isCraftable && favourites.includes(item.name) ? `<p><strong class="font-semibold">Missing:</strong> <span class="text-red-500">${missingText}</span></p>` : ''}
+              <p><strong class="font-semibold">Build Cost:</strong> ${buildCost}</p>
               <p><strong class="font-semibold">Price:</strong> ${item.price}</p>
               <p><strong class="font-semibold">Expansion:</strong> ${item.expansion}</p>
             </div>


### PR DESCRIPTION
## Summary
- add a helper to compute build cost from missing materials
- display build cost on item cards
- document build cost feature in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686815d145bc83279a56e9d296af62df