### PR TITLE
Fix caching clone in service worker

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -78,8 +78,9 @@ self.addEventListener('fetch', event => {
       fetch(event.request)
         .then(networkResponse => {
           if (networkResponse && networkResponse.status === 200) {
+            const responseClone = networkResponse.clone();
             caches.open(CACHE_NAME).then(cache => {
-              cache.put(event.request, networkResponse.clone());
+              cache.put(event.request, responseClone);
             });
           }
           return networkResponse;


### PR DESCRIPTION
## Summary
- ensure JSON responses are cloned before storing in the cache

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868177879d88327b7c34fa63e31f0e0