### PR TITLE
Update cost labels on item cards

### DIFF
--- a/js/ui/components.js
+++ b/js/ui/components.js
@@ -251,8 +251,8 @@ export function renderAllItemsView(items, inventory, favourites) {
             <div class="text-sm space-y-1">
               <p><strong class="font-semibold">Requires:</strong> ${required || 'None'}</p>
               <p><strong class="font-semibold">Missing:</strong> <span class="${missingText === 'None' ? '' : 'text-red-500'}">${missingText}</span></p>
-              <p><strong class="font-semibold">Build Cost:</strong> ${buildCost}</p>
-              <p><strong class="font-semibold">Price:</strong> ${item.price}</p>
+              <p><strong class="font-semibold">Build Cost:</strong> <span class="text-red-500">${buildCost}</span></p>
+              <p><strong class="font-semibold">Craft Cost:</strong> ${item.price}</p>
               <p><strong class="font-semibold">Expansion:</strong> ${item.expansion}</p>
             </div>
           </div>
@@ -376,8 +376,8 @@ export function renderCraftableItemsView(items, inventory, favourites) {
             <div class="text-sm space-y-1">
               <p><strong class="font-semibold">Requires:</strong> ${required || 'None'}</p>
               ${!isCraftable && favourites.includes(item.name) ? `<p><strong class="font-semibold">Missing:</strong> <span class="text-red-500">${missingText}</span></p>` : ''}
-              <p><strong class="font-semibold">Build Cost:</strong> ${buildCost}</p>
-              <p><strong class="font-semibold">Price:</strong> ${item.price}</p>
+              <p><strong class="font-semibold">Build Cost:</strong> <span class="text-red-500">${buildCost}</span></p>
+              <p><strong class="font-semibold">Craft Cost:</strong> ${item.price}</p>
               <p><strong class="font-semibold">Expansion:</strong> ${item.expansion}</p>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- rename `Price` label to `Craft Cost`
- highlight the numeric build cost in red

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686817ed96508327861660fecef79fcb