### PR TITLE
Move control buttons to header

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,9 +16,8 @@
   <header class="app-header">
     <div class="container mx-auto flex items-center justify-between p-4">
       <a href="index.html" class="app-logo-text text-xl sm:text-2xl">Maladum Crafting Companion</a>
-      <nav id="headerNavLinks">
-        <!-- Example: <a href="#about" class="text-white hover:text-gray-300 px-3">About</a> -->
-        <!-- Links can be added here or by JS if dynamic -->
+      <nav id="headerNavLinks" class="flex items-center gap-2">
+        <!-- Buttons will be injected here -->
       </nav>
     </div>
   </header>

--- a/js/ui/components.js
+++ b/js/ui/components.js
@@ -59,6 +59,16 @@ function calculateBuildCost(item, inventory) {
   return total;
 }
 
+function renderHeaderButtons() {
+  const headerNav = document.getElementById('headerNavLinks');
+  if (!headerNav) return;
+
+  headerNav.innerHTML = `
+    <button id="viewToggleBtn" class="btn mr-2" data-view="craftable">All Items</button>
+    <button id="settingsBtn" class="btn">⚙️ Settings</button>
+  `;
+}
+
 export function renderHome(materials, items) {
   cachedMaterials = materials;
   cachedItems = items;
@@ -70,19 +80,8 @@ export function renderHome(materials, items) {
   // Clear previous content
   app.innerHTML = '';
 
-  // Create Control Bar Section
-  const controlSection = document.createElement('section');
-  controlSection.id = 'controlsSection';
-  // Added fade-in to sections
-  controlSection.className = 'fade-in mb-6 p-4 rounded shadow-lg';
-  controlSection.innerHTML = `
-    <h2 class="text-xl font-heading mb-3 sr-only">Controls</h2> <!-- Screen-reader only title for now -->
-    <div class="flex flex-wrap gap-2 items-center">
-      <button id="viewToggleBtn" class="btn mr-2" data-view="craftable">All Items</button>
-      <button id="settingsBtn" class="btn">⚙️ Settings</button>
-    </div>
-  `;
-  app.appendChild(controlSection);
+  // Place header buttons
+  renderHeaderButtons();
 
   // Create Materials Section
   const materialsSection = document.createElement('section');


### PR DESCRIPTION
## Summary
- move view toggle and Settings buttons into the page header
- inject the header buttons dynamically via JavaScript

## Testing
- `node -e "require('./js/ui/components.js')"`

------
https://chatgpt.com/codex/tasks/task_e_68681972d88c8327b827bc25beedc6dd