### PR TITLE
Add relic background style

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -304,7 +304,10 @@ input[type="number"] {
 .rarity-border-common { border-color: green; }
 .rarity-border-uncommon { border-color: yellow; }
 .rarity-border-rare { border-color: lightblue; }
-.relic-border { border-color: var(--accent-gold); }
+.relic-border {
+  border-color: var(--accent-gold);
+  background-color: var(--relic-bg);
+}
 
 /* Styles for the icon zoom modal */
 .icon-modal {

--- a/theme.css
+++ b/theme.css
@@ -13,6 +13,7 @@
   --maladum-red: #8B0000;
   --accent-gold: #c5a572; /* Spec name for --maladum-gold */
   --accent-green: #1b5e20;
+  --relic-bg: #EBD9BF; /* light parchment-gold blend */
 
   /* Additional useful variables from Event Cards styles.css */
   --dark-bg: #121212; /* Main body background in Event Cards */


### PR DESCRIPTION
## Summary
- add `--relic-bg` color variable to palette
- use this variable to give `.relic-border` a parchment-like background

## Testing
- `node -e "const fs=require('fs');const items=JSON.parse(fs.readFileSync('items.json','utf8'));console.log('relicCount',items.filter(i=>i.relic>0).length);"`
- `node -e "const fs=require('fs');console.log(/--relic-bg/.test(fs.readFileSync('theme.css','utf8')) && /background-color:\s*var\(--relic-bg\)/.test(fs.readFileSync('styles.css','utf8')));"`

------
https://chatgpt.com/codex/tasks/task_e_68681f32ed5c83279796afd35ea53698